### PR TITLE
Add pipeline for tagged release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,20 @@ jobs:
         - docker build -t tomochain/tomomaster .
       deploy:
         provider: script
-        script: bash docker_push.sh
+        script:
+          - bash docker_push.sh latest
+          - bash docker_push.sh $TRAVIS_BUILD_ID
         on:
           branch: master
+          tags: false
+      deploy:
+        provider: script
+        script:
+          - bash docker_push.sh latest
+          - bash docker_push.sh $TRAVIS_TAG
+        on:
+          branch: master
+          tags: true
     - stage: Trigger rebuild of infrastructure images
       sudo: false
       install: skip

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-docker tag tomochain/tomomaster tomochain/tomomaster:latest
-docker tag tomochain/tomomaster tomochain/tomomaster:$TRAVIS_BUILD_ID
-docker push tomochain/tomomaster:latest
-docker push tomochain/tomomaster:$TRAVIS_BUILD_ID
+docker tag tomochain/tomomaster tomochain/tomomaster:$1
+docker push tomochain/tomomaster:$1


### PR DESCRIPTION
This PR aims to add pipeline for the tagged release.
- Publish a Github? (to check if needed as tagged commit are automatically releases on github)
- Push the Docker image for latest and the tag of the release
