### PR TITLE
update withdrawal estimation time formula

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -128,7 +128,7 @@ Vue.prototype.getSecondsToHms = function (number) {
         return 'Available to withdraw'
     }
 
-    number = number / 2
+    number = number * 2
 
     let h = Math.floor(number / 3600)
     let m = Math.floor(number % 3600 / 60)


### PR DESCRIPTION
Issue: Wrong withdrawal estimation time formula
Actual: 2 blocks cost 1 second
Expect: 1 block costs 2 seconds