### PR TITLE
improve loading screen

### DIFF
--- a/app/components/candidates/List.vue
+++ b/app/components/candidates/List.vue
@@ -39,7 +39,14 @@
                 </div>
             </div>
         </div>
-        <div class="container">
+
+        <div
+            v-if="candidates.length <= 0"
+            class="tomo-loading"/>
+
+        <div
+            v-else
+            class="container">
             <div class="row">
                 <div class="col-12">
                     <h3 class="section-title">
@@ -56,7 +63,6 @@
                 :sort-by.sync="sortBy"
                 :sort-desc.sync="sortDesc"
                 :class="'tomo-table tomo-table--candidates ' + tableCssClass"
-                :show-empty="true"
                 empty-text="There are no candidates to show"
                 stacked="md" >
 


### PR DESCRIPTION
The screen will now show a loading icon instead of text if the table is loading
![screenshot from 2018-09-21 11-22-41](https://user-images.githubusercontent.com/24842503/45860315-b0907e80-bd90-11e8-89cd-3cbfb652f01b.png)

