### PR TITLE
fix button space

### DIFF
--- a/app/assets/scss/components/_form.scss
+++ b/app/assets/scss/components/_form.scss
@@ -19,7 +19,13 @@
     }
 
     .buttons {
-        margin-top: 20px;
+        margin-top: 10px;
+
+        @include media-breakpoint-down(sm) {
+            button {
+                margin-bottom:5px
+            }
+        }
     }
 
     .btn {

--- a/app/assets/scss/trumps/_custom.scss
+++ b/app/assets/scss/trumps/_custom.scss
@@ -147,3 +147,6 @@
     }
 }
 
+.estimate-reward {
+    margin-top: -10px
+}

--- a/app/components/voters/Voting.vue
+++ b/app/components/voters/Voting.vue
@@ -65,10 +65,12 @@
                             </b-input-group>
                         </b-form-group>
                         <div>
-                            <div class="float-left">
+                            <div
+                                class="row float-left col-12 mb-2">
                                 <estimate-reward
                                     :value="voteValue"
-                                    :candidate="candidate"/>
+                                    :candidate="candidate"
+                                    class="estimate-reward"/>
                             </div>
                             <div class="buttons text-right">
                                 <b-button


### PR DESCRIPTION
- Add 'margin' for buttons when screen size less than sm size
- A separate line for estimate reward line

iphone 4 screen shoot:
![image](https://user-images.githubusercontent.com/24842503/56351067-72f4b680-61f6-11e9-9606-a8da8de7e527.png)
