### PR TITLE
fix notification bell status issue

### DIFF
--- a/app/assets/scss/components/_notification.scss
+++ b/app/assets/scss/components/_notification.scss
@@ -35,10 +35,10 @@
 .notification__bell {
     position: absolute;
     top: -25%;
-    left: 60%;
+    left: 30%;
     @include media-breakpoint-down(sm) {
         top: -25% !important;
-        left: 60% !important;
+        left: 30% !important;
     }
 }
 


### PR DESCRIPTION
The status icon deviates a bit to the right because of changing setting and status buttons
![image](https://user-images.githubusercontent.com/24842503/57118839-1e257400-6d90-11e9-8221-dc6b2a2bc649.png)
