### PR TITLE
[1.5.0]Disable name sorting

### DIFF
--- a/app/components/candidates/List.vue
+++ b/app/components/candidates/List.vue
@@ -189,7 +189,7 @@ export default {
                 {
                     key: 'name',
                     label: 'Name',
-                    sortable: true
+                    sortable: false
                 },
                 {
                     key: 'capacity',


### PR DESCRIPTION
Some masternodes don't have name(remain Anonymous) which affects name sorting in masternode list table