### PR TITLE
[1.5.0]Refactor updateLatestSignedBlock function

### DIFF
--- a/crawl.js
+++ b/crawl.js
@@ -481,27 +481,29 @@ function diff (a, b) {
 
 async function updateLatestSignedBlock (blk) {
     try {
-        for (let hash of ((blk || {}).transactions || [])) {
-            let tx = await web3Rpc.eth.getTransaction(hash)
-            if ((tx || {}).to === config.get('blockchain.blockSignerAddress')) {
-                let signer = tx.from
-                let buff = Buffer.from((tx.input || '').substring(2), 'hex')
-                let sbuff = buff.slice(buff.length - 32, buff.length)
-                let bN = ((await web3Rpc.eth.getBlock('0x' + sbuff.toString('hex'))) || {}).number
-                if (!bN) {
-                    logger.debug('Bypass signer %s sign %s', signer, '0x' + sbuff.toString('hex'))
-                    continue
-                }
-                logger.debug('Sign block %s by signer %s', bN, signer)
-                await db.Candidate.updateOne({
-                    smartContractAddress: config.get('blockchain.validatorAddress'),
-                    candidate: signer.toLowerCase()
-                }, {
-                    $set: {
-                        latestSignedBlock: bN
+        const transactions = (blk || {}).transactions
+        if (transactions.length > 0) {
+            await Promise.all(transactions.map(async (hash) => {
+                let tx = await web3Rpc.eth.getTransaction(hash)
+                if ((tx || {}).to === config.get('blockchain.blockSignerAddress')) {
+                    let signer = tx.from
+                    let buff = Buffer.from((tx.input || '').substring(2), 'hex')
+                    let sbuff = buff.slice(buff.length - 32, buff.length)
+                    let bN = ((await web3Rpc.eth.getBlock('0x' + sbuff.toString('hex'))) || {}).number
+                    if (!bN) {
+                        logger.debug('Bypass signer %s sign %s', signer, '0x' + sbuff.toString('hex'))
                     }
-                }, { upsert: false })
-            }
+                    logger.debug('Sign block %s by signer %s', bN, signer)
+                    await db.Candidate.updateOne({
+                        smartContractAddress: config.get('blockchain.validatorAddress'),
+                        candidate: signer.toLowerCase()
+                    }, {
+                        $set: {
+                            latestSignedBlock: bN
+                        }
+                    }, { upsert: false })
+                }
+            }))
         }
     } catch (e) {
         logger.error('updateLatestSignedBlock %s', e)


### PR DESCRIPTION
issue: https://github.com/tomochain/tomomaster/issues/647
The current function took a lot of time to update db around 60 seconds. This could be the cause of sorting by latestSignedBlock