### PR TITLE
remove candidate name if tx is withdraw

### DIFF
--- a/apis/transactions.js
+++ b/apis/transactions.js
@@ -60,7 +60,10 @@ router.get('/voter/:voter', [
                 smartContractAddress: config.get('blockchain.validatorAddress'),
                 candidate: t.candidate
             }) || {}
-            c.name = b.name || 'Anonymous'
+
+            if (t.event === 'Withdraw') {
+                c.name = ''
+            } else { c.name = b.name || 'Anonymous' }
             return c
         }))
         return res.json({

--- a/app/assets/scss/components/_navbar.scss
+++ b/app/assets/scss/components/_navbar.scss
@@ -135,6 +135,7 @@
     a {
         text-align: center;
         text-decoration: none;
+        white-space: pre-wrap;
         cursor: pointer;
 
         &:hover {

--- a/app/components/voters/View.vue
+++ b/app/components/voters/View.vue
@@ -507,7 +507,7 @@ export default {
                         event: tx.event,
                         cap: new BigNumber(tx.capacity).div(10 ** 18).toNumber(),
                         createdAt: moment(tx.createdAt).fromNow(),
-                        name: tx.name,
+                        name: tx.name || '---',
                         candidateCap: (new BigNumber(tx.currentCandidateCap).div(10 ** 18).toNumber()) || '---'
                     })
                 })


### PR DESCRIPTION
The current displaying withdrawal transaction is showing Anonymous name
![image](https://user-images.githubusercontent.com/24842503/59426867-7b86f900-8e03-11e9-99f9-84bcf150c7d4.png)
 After removing Anonymous name:
![image](https://user-images.githubusercontent.com/24842503/59426795-4a0e2d80-8e03-11e9-8b0e-45fa1c1c0c40.png)
 Also solved issue: https://github.com/tomochain/tomomaster/issues/670